### PR TITLE
add support for pcbc mode

### DIFF
--- a/lib/des.js
+++ b/lib/des.js
@@ -5,3 +5,4 @@ exports.Cipher = require('./des/cipher');
 exports.DES = require('./des/des');
 exports.CBC = require('./des/cbc');
 exports.EDE = require('./des/ede');
+exports.PCBC = require('./des/pcbc');

--- a/lib/des/pcbc.js
+++ b/lib/des/pcbc.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var assert = require('minimalistic-assert');
+var inherits = require('inherits');
+
+var proto = {};
+
+function PCBCState(iv) {
+  assert.equal(iv.length, 8, 'Invalid IV length');
+
+  this.iv = new Array(8);
+  for (var i = 0; i < this.iv.length; i++)
+    this.iv[i] = iv[i];
+}
+
+function instantiate(Base) {
+  function PCBC(options) {
+    Base.call(this, options);
+    this._pcbcInit();
+  }
+  inherits(PCBC, Base);
+
+  var keys = Object.keys(proto);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    PCBC.prototype[key] = proto[key];
+  }
+
+  PCBC.create = function create(options) {
+    return new PCBC(options);
+  };
+
+  return PCBC;
+}
+
+exports.instantiate = instantiate;
+
+proto._pcbcInit = function _pcbcInit() {
+  var state = new PCBCState(this.options.iv);
+  this._pcbcState = state;
+};
+
+proto._update = function _update(inp, inOff, out, outOff) {
+  var state = this._pcbcState;
+  var superProto = this.constructor.super_.prototype;
+
+  var iv = state.iv;
+  if (this.type === 'encrypt') {
+    for (var i = 0; i < this.blockSize; i++)
+      iv[i] ^= inp[inOff + i];
+
+    superProto._update.call(this, iv, 0, out, outOff);
+
+    for (var i = 0; i < this.blockSize; i++)
+      iv[i] = out[outOff + i];
+    
+    for (var i = 0; i < this.blockSize; i++)
+      iv[i] ^= inp[inOff + i];
+  } else {
+    superProto._update.call(this, inp, inOff, out, outOff);
+
+    for (var i = 0; i < this.blockSize; i++)
+      out[outOff + i] ^= iv[i];
+
+    for (var i = 0; i < this.blockSize; i++)
+      iv[i] = inp[inOff + i];
+
+    for (var i = 0; i < this.blockSize; i++)
+      iv[i] ^= out[outOff + i];
+  }
+};

--- a/test/pcbc-test.js
+++ b/test/pcbc-test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var assert = require('assert');
+var Buffer = require('buffer').Buffer;
+
+var des = require('../');
+
+var fixtures = require('./fixtures');
+var bin = fixtures.bin;
+
+describe('DES-PCBC', function() {
+  var PCBC = des.PCBC.instantiate(des.DES);
+
+  describe('encryption/decryption', function() {
+    var vectors = [
+      {
+        key: '133457799bbcdff1',
+        iv: '0102030405060708',
+        input: '0123456789abcdef',
+        expected: 'e61690cc695580f6'
+      },
+      {
+        key: '0000000000000000',
+        iv: 'ffffffffffffffff',
+        input: '0000000000000000',
+        expected: '355550b2150e2451'
+      },
+      {
+        key: 'a3a3a3a3b3b3b3b3',
+        iv: 'cdcdcdcdcdcdcdcd',
+        input: 'cccccccccccccccc',
+        expected: 'd3b46e94d6beb89f'
+      },
+      {
+        key: 'deadbeefabbadead',
+        iv: 'a0da0da0da0da0da',
+        input: '0102030405060708',
+        expected: 'aa8f918a8290790b'
+      },
+      {
+        key: 'aabbccddeeff0011',
+        iv: 'fefefefefefefefe',
+        input: '0102030405060708090a0102030405060708090a0102030405060708090a' +
+               '0102030405060708090a0102030405060607080a010203040506',
+        expected: 'b55586b5e2394ea8d6d3d9f783a62bdc03b85e4418744ae6cdd6350f4' +
+                  '792482bad99c3d16bdbf76cd0c34977c2a865d86184263401f14d0b'
+      }
+    ];
+
+    vectors.forEach(function(vec, i) {
+      it('should encrypt vector ' + i, function() {
+        var key = Buffer.from(vec.key, 'hex');
+        var iv = Buffer.from(vec.iv, 'hex');
+        var input = Buffer.from(vec.input, 'hex');
+
+        var enc = PCBC.create({
+          type: 'encrypt',
+          key: key,
+          iv: iv,
+          padding: false
+        });
+        var out = Buffer.from(enc.update(input).concat(enc.final()));
+
+        var expected = Buffer.from(vec.expected, 'hex');
+        assert.deepEqual(out, expected);
+
+        var dec = PCBC.create({
+          type: 'decrypt',
+          key: key,
+          iv: iv,
+          padding: false
+        });
+        assert.deepEqual(Buffer.from(dec.update(out).concat(dec.final())), input);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Unfortunately, Node.js does not support des pcbc. Therefore you can't make a useful test case like e.g. cbc. 